### PR TITLE
fix activeThread count

### DIFF
--- a/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
@@ -81,6 +81,8 @@ public class SpeedometerFilterPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
         Schema outputSchema = inputSchema;
         control.run(task.dump(), outputSchema);
+        SpeedometerSpeedAggregator aggregator = SpeedometerSpeedAggregator.getInstance(task);
+        aggregator.showOverallMessage();
     }
 
     @Override

--- a/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
@@ -81,8 +81,6 @@ public class SpeedometerFilterPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
         Schema outputSchema = inputSchema;
         control.run(task.dump(), outputSchema);
-        SpeedometerSpeedAggregator aggregator = SpeedometerSpeedAggregator.getInstance(task);
-        aggregator.showOverallMessage();
     }
 
     @Override
@@ -113,6 +111,7 @@ public class SpeedometerFilterPlugin
             this.pageReader = new PageReader(schema);
             this.timestampFormatters = Timestamps.newTimestampColumnFormatters(task, schema, task.getColumnOptions());
             this.pageBuilder = new PageBuilder(allocator, schema, pageOutput);
+            this.controller.start(System.currentTimeMillis());
         }
 
         @Override

--- a/src/main/java/org/embulk/filter/SpeedometerSpeedAggregator.java
+++ b/src/main/java/org/embulk/filter/SpeedometerSpeedAggregator.java
@@ -145,7 +145,7 @@ class SpeedometerSpeedAggregator {
         showLogMessage(activeControllerCount.get(), currentTotalSize, timeDelta, currentBytesPerSec, currentTotalRecords, currentRecordsPerSec);
     }
 
-    public void showOverallMessage() {
+    private void showOverallMessage() {
         long timeDelta = System.currentTimeMillis() - globalStartTime.get();
         timeDelta = timeDelta > 0 ? timeDelta : 1;
         long bytesPerSec = (globalTotalBytes.get() * 1000) / timeDelta;

--- a/src/main/java/org/embulk/filter/SpeedometerSpeedAggregator.java
+++ b/src/main/java/org/embulk/filter/SpeedometerSpeedAggregator.java
@@ -145,7 +145,7 @@ class SpeedometerSpeedAggregator {
         showLogMessage(activeControllerCount.get(), currentTotalSize, timeDelta, currentBytesPerSec, currentTotalRecords, currentRecordsPerSec);
     }
 
-    private void showOverallMessage() {
+    public void showOverallMessage() {
         long timeDelta = System.currentTimeMillis() - globalStartTime.get();
         timeDelta = timeDelta > 0 ? timeDelta : 1;
         long bytesPerSec = (globalTotalBytes.get() * 1000) / timeDelta;

--- a/src/main/java/org/embulk/filter/SpeedometerSpeedController.java
+++ b/src/main/java/org/embulk/filter/SpeedometerSpeedController.java
@@ -25,6 +25,13 @@ class SpeedometerSpeedController {
         this.aggregator = aggregator;
     }
 
+    public void start(long nowTime) {
+        if (startTime == 0) {
+            startTime = nowTime;
+            aggregator.startController(this, startTime);
+        }
+    }
+
     public void stop() {
         startNewPeriod(0);
         aggregator.stopController(this);


### PR DESCRIPTION
今回起きていた原因

## 事象
１番最後に出るspeedometorのlog値が転送されている転送量と違った

## 原因: 
{speedometer: {active: 0, total: 10.0gb, sec: 1:15, speed: 131mb/s, records: 30,000,000, record-speed: 395,272/s}}
上記のactive 0 になった際にメッセージがでる様になっているが、ここのカウントのやり方が間違っていたと思われる。

https://github.com/primenumber-dev/embulk-filter-speedometer/blob/master/README.md?plain=1#L14
- **log_interval_seconds**: Interval seconds to write log message periodically. (integer, optional, default: 10). If this value is set to 0, then interval message is not shown. It only show message when there is no active thread.

It only show message when there is no active thread.
このときに出るメッセージ
no active thread = 転送が終わったタイミング


なぜ今回のケースで起きていたか
activeThreadのカウントがデータが無い場合において,マイナスになるので、0にならずに起きた

atomicLongでactiveThreadの数をカウントしており、
データがoutputThreadに来れば、データの量をチェックされて、activeThreadの数が(column visitorでスピードをチェックしているところで)incrementされるコードであった。
-> データがこないとactiveThreadのカウントがincrementされず、outputThreadの終了の場合はdecrementされる

increment
https://github.com/primenumber-dev/embulk-filter-speedometer/blob/93fa1dc1cfe127a65d83d7b7bc67cd88de86b28d/src/main/java/org/embulk/filter/SpeedometerSpeedController.java#L68

decrement
https://github.com/primenumber-dev/embulk-filter-speedometer/blob/93fa1dc1cfe127a65d83d7b7bc67cd88de86b28d/src/main/java/org/embulk/filter/SpeedometerSpeedController.java#L30


今回のデータは、片方のデータが空(header だけ)であった。
https://s3.console.aws.amazon.com/s3/buckets/trocco-test-nakamu?region=ap-northeast-1&prefix=20220307/&showversions=false

## この問題が他に起きていたか
転送終了までに、特定のoutputThreadにずっとデータが来なかった場合
例外として、空のデータと、少量のデータを転送する場合にはおらない場合がある
少量のデータが、先に処理されて、そのあとに空のデータを処理すると、空のデータの場合はspeedometorの値が表示されていなくても、意味としては転送量としての表示は変わらない。



## 修正
PageOutputがインスタンス化されたタイミングで、activeThreadのカウントを増えるようにした。
https://github.com/primenumber-dev/embulk-filter-speedometer/pull/4/files#diff-e8df244eb9d91697ae2143176e179a2f3f136dd8d91cce2ccd04d02b4ce361f9L114

outputThreadは転送に使われるので、データの入るタイミングではなく、インスタンス化したタイミングで妥当
現状のコードのデータがこないからカウントをスタートしないという形にしなくて良い（そもそもこのコードが正しいか疑問があるが）
とても小さいデータの場合、データが来るまでのオーバーヘッドがあり、転送速度の値が遅くなったように見えてしまう

##この変更を入れたあとの監視
`{speedometer: {active: -`

activeThreadがマイナスになるはずはないので、ここを計測するのが良いかと思います。

## 動作結果
https://docs.google.com/spreadsheets/d/1skDixjwnYteiKlUNJKMkOQaXvdepXRh_VmZaXVxRLso/edit#gid=1137354101